### PR TITLE
support `impl Trait` in NLL type-checking

### DIFF
--- a/src/librustc/infer/anon_types/mod.rs
+++ b/src/librustc/infer/anon_types/mod.rs
@@ -1,0 +1,200 @@
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use hir::def_id::DefId;
+use infer::{InferCtxt, InferOk, TypeVariableOrigin};
+use syntax::ast;
+use traits::{self, PredicateObligation};
+use ty::{self, Ty};
+use ty::fold::{BottomUpFolder, TypeFoldable};
+use ty::subst::Substs;
+use util::nodemap::DefIdMap;
+
+pub type AnonTypeMap<'tcx> = DefIdMap<AnonTypeDecl<'tcx>>;
+
+/// Information about the anonymous, abstract types whose values we
+/// are inferring in this function (these are the `impl Trait` that
+/// appear in the return type).
+#[derive(Copy, Clone, Debug)]
+pub struct AnonTypeDecl<'tcx> {
+    /// The substitutions that we apply to the abstract that that this
+    /// `impl Trait` desugars to. e.g., if:
+    ///
+    ///     fn foo<'a, 'b, T>() -> impl Trait<'a>
+    ///
+    /// winds up desugared to:
+    ///
+    ///     abstract type Foo<'x, T>: Trait<'x>
+    ///     fn foo<'a, 'b, T>() -> Foo<'a, T>
+    ///
+    /// then `substs` would be `['a, T]`.
+    pub substs: &'tcx Substs<'tcx>,
+
+    /// The type variable that represents the value of the abstract type
+    /// that we require. In other words, after we compile this function,
+    /// we will be created a constraint like:
+    ///
+    ///     Foo<'a, T> = ?C
+    ///
+    /// where `?C` is the value of this type variable. =) It may
+    /// naturally refer to the type and lifetime parameters in scope
+    /// in this function, though ultimately it should only reference
+    /// those that are arguments to `Foo` in the constraint above. (In
+    /// other words, `?C` should not include `'b`, even though it's a
+    /// lifetime parameter on `foo`.)
+    pub concrete_ty: Ty<'tcx>,
+
+    /// True if the `impl Trait` bounds include region bounds.
+    /// For example, this would be true for:
+    ///
+    ///     fn foo<'a, 'b, 'c>() -> impl Trait<'c> + 'a + 'b
+    ///
+    /// but false for:
+    ///
+    ///     fn foo<'c>() -> impl Trait<'c>
+    ///
+    /// unless `Trait` was declared like:
+    ///
+    ///     trait Trait<'c>: 'c
+    ///
+    /// in which case it would be true.
+    ///
+    /// This is used during regionck to decide whether we need to
+    /// impose any additional constraints to ensure that region
+    /// variables in `concrete_ty` wind up being constrained to
+    /// something from `substs` (or, at minimum, things that outlive
+    /// the fn body). (Ultimately, writeback is responsible for this
+    /// check.)
+    pub has_required_region_bounds: bool,
+}
+
+impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
+    /// Replace all anonymized types in `value` with fresh inference variables
+    /// and creates appropriate obligations. For example, given the input:
+    ///
+    ///     impl Iterator<Item = impl Debug>
+    ///
+    /// this method would create two type variables, `?0` and `?1`. It would
+    /// return the type `?0` but also the obligations:
+    ///
+    ///     ?0: Iterator<Item = ?1>
+    ///     ?1: Debug
+    ///
+    /// Moreover, it returns a `AnonTypeMap` that would map `?0` to
+    /// info about the `impl Iterator<..>` type and `?1` to info about
+    /// the `impl Debug` type.
+    pub fn instantiate_anon_types<T: TypeFoldable<'tcx>>(
+        &self,
+        body_id: ast::NodeId,
+        param_env: ty::ParamEnv<'tcx>,
+        value: &T,
+    ) -> InferOk<'tcx, (T, AnonTypeMap<'tcx>)> {
+        debug!(
+            "instantiate_anon_types(value={:?}, body_id={:?}, param_env={:?})",
+            value,
+            body_id,
+            param_env,
+        );
+        let mut instantiator = Instantiator {
+            infcx: self,
+            body_id,
+            param_env,
+            anon_types: DefIdMap(),
+            obligations: vec![],
+        };
+        let value = instantiator.instantiate_anon_types_in_map(value);
+        InferOk {
+            value: (value, instantiator.anon_types),
+            obligations: instantiator.obligations,
+        }
+    }
+}
+
+struct Instantiator<'a, 'gcx: 'tcx, 'tcx: 'a> {
+    infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,
+    body_id: ast::NodeId,
+    param_env: ty::ParamEnv<'tcx>,
+    anon_types: AnonTypeMap<'tcx>,
+    obligations: Vec<PredicateObligation<'tcx>>,
+}
+
+impl<'a, 'gcx, 'tcx> Instantiator<'a, 'gcx, 'tcx> {
+    fn instantiate_anon_types_in_map<T: TypeFoldable<'tcx>>(&mut self, value: &T) -> T {
+        debug!("instantiate_anon_types_in_map(value={:?})", value);
+        value.fold_with(&mut BottomUpFolder {
+            tcx: self.infcx.tcx,
+            fldop: |ty| if let ty::TyAnon(def_id, substs) = ty.sty {
+                self.fold_anon_ty(ty, def_id, substs)
+            } else {
+                ty
+            },
+        })
+    }
+
+    fn fold_anon_ty(
+        &mut self,
+        ty: Ty<'tcx>,
+        def_id: DefId,
+        substs: &'tcx Substs<'tcx>,
+    ) -> Ty<'tcx> {
+        let infcx = self.infcx;
+        let tcx = infcx.tcx;
+
+        debug!(
+            "instantiate_anon_types: TyAnon(def_id={:?}, substs={:?})",
+            def_id,
+            substs
+        );
+
+        // Use the same type variable if the exact same TyAnon appears more
+        // than once in the return type (e.g. if it's passed to a type alias).
+        if let Some(anon_defn) = self.anon_types.get(&def_id) {
+            return anon_defn.concrete_ty;
+        }
+        let span = tcx.def_span(def_id);
+        let ty_var = infcx.next_ty_var(TypeVariableOrigin::TypeInference(span));
+
+        let predicates_of = tcx.predicates_of(def_id);
+        let bounds = predicates_of.instantiate(tcx, substs);
+        debug!("instantiate_anon_types: bounds={:?}", bounds);
+
+        let required_region_bounds = tcx.required_region_bounds(ty, bounds.predicates.clone());
+        debug!(
+            "instantiate_anon_types: required_region_bounds={:?}",
+            required_region_bounds
+        );
+
+        self.anon_types.insert(
+            def_id,
+            AnonTypeDecl {
+                substs,
+                concrete_ty: ty_var,
+                has_required_region_bounds: !required_region_bounds.is_empty(),
+            },
+        );
+        debug!("instantiate_anon_types: ty_var={:?}", ty_var);
+
+        for predicate in bounds.predicates {
+            // Change the predicate to refer to the type variable,
+            // which will be the concrete type, instead of the TyAnon.
+            // This also instantiates nested `impl Trait`.
+            let predicate = self.instantiate_anon_types_in_map(&predicate);
+
+            let cause = traits::ObligationCause::new(span, self.body_id, traits::SizedReturnType);
+
+            // Require that the predicate holds for the concrete type.
+            debug!("instantiate_anon_types: predicate={:?}", predicate);
+            self.obligations
+                .push(traits::Obligation::new(cause, self.param_env, predicate));
+        }
+
+        ty_var
+    }
+}

--- a/src/librustc/infer/anon_types/mod.rs
+++ b/src/librustc/infer/anon_types/mod.rs
@@ -93,20 +93,34 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     /// Moreover, it returns a `AnonTypeMap` that would map `?0` to
     /// info about the `impl Iterator<..>` type and `?1` to info about
     /// the `impl Debug` type.
+    ///
+    /// # Parameters
+    ///
+    /// - `parent_def_id` -- we will only instantiate anonymous types
+    ///   with this parent. This is typically the def-id of the function
+    ///   in whose return type anon types are being instantiated.
+    /// - `body_id` -- the body-id with which the resulting obligations should
+    ///   be associated
+    /// - `param_env` -- the in-scope parameter environment to be used for
+    ///   obligations
+    /// - `value` -- the value within which we are instantiating anon types
     pub fn instantiate_anon_types<T: TypeFoldable<'tcx>>(
         &self,
+        parent_def_id: DefId,
         body_id: ast::NodeId,
         param_env: ty::ParamEnv<'tcx>,
         value: &T,
     ) -> InferOk<'tcx, (T, AnonTypeMap<'tcx>)> {
         debug!(
-            "instantiate_anon_types(value={:?}, body_id={:?}, param_env={:?})",
+            "instantiate_anon_types(value={:?}, parent_def_id={:?}, body_id={:?}, param_env={:?})",
             value,
+            parent_def_id,
             body_id,
             param_env,
         );
         let mut instantiator = Instantiator {
             infcx: self,
+            parent_def_id,
             body_id,
             param_env,
             anon_types: DefIdMap(),
@@ -480,6 +494,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
 
 struct Instantiator<'a, 'gcx: 'tcx, 'tcx: 'a> {
     infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,
+    parent_def_id: DefId,
     body_id: ast::NodeId,
     param_env: ty::ParamEnv<'tcx>,
     anon_types: AnonTypeMap<'tcx>,
@@ -489,11 +504,33 @@ struct Instantiator<'a, 'gcx: 'tcx, 'tcx: 'a> {
 impl<'a, 'gcx, 'tcx> Instantiator<'a, 'gcx, 'tcx> {
     fn instantiate_anon_types_in_map<T: TypeFoldable<'tcx>>(&mut self, value: &T) -> T {
         debug!("instantiate_anon_types_in_map(value={:?})", value);
+        let tcx = self.infcx.tcx;
         value.fold_with(&mut BottomUpFolder {
-            tcx: self.infcx.tcx,
-            fldop: |ty| if let ty::TyAnon(def_id, substs) = ty.sty {
-                self.fold_anon_ty(ty, def_id, substs)
-            } else {
+            tcx,
+            fldop: |ty| {
+                if let ty::TyAnon(def_id, substs) = ty.sty {
+                    // Check that this is `impl Trait` type is declared by
+                    // `parent_def_id`. During the first phase of type-check, this
+                    // is true, but during NLL type-check, we sometimes encounter
+                    // `impl Trait` types in e.g. inferred closure signatures that
+                    // are not 'local' to the current function and hence which
+                    // ought not to be instantiated.
+                    if let Some(anon_node_id) = tcx.hir.as_local_node_id(def_id) {
+                        let anon_parent_node_id = tcx.hir.get_parent(anon_node_id);
+                        let anon_parent_def_id = tcx.hir.local_def_id(anon_parent_node_id);
+                        if self.parent_def_id == anon_parent_def_id {
+                            return self.fold_anon_ty(ty, def_id, substs);
+                        }
+
+                        debug!("instantiate_anon_types_in_map: \
+                                encountered anon with wrong parent \
+                                def_id={:?} \
+                                anon_parent_def_id={:?}",
+                               def_id,
+                               anon_parent_def_id);
+                    }
+                }
+
                 ty
             },
         })

--- a/src/librustc/infer/anon_types/mod.rs
+++ b/src/librustc/infer/anon_types/mod.rs
@@ -9,11 +9,13 @@
 // except according to those terms.
 
 use hir::def_id::DefId;
-use infer::{InferCtxt, InferOk, TypeVariableOrigin};
+use infer::{self, InferCtxt, InferOk, TypeVariableOrigin};
+use infer::outlives::free_region_map::FreeRegionRelations;
 use syntax::ast;
 use traits::{self, PredicateObligation};
 use ty::{self, Ty};
 use ty::fold::{BottomUpFolder, TypeFoldable};
+use ty::outlives::Component;
 use ty::subst::Substs;
 use util::nodemap::DefIdMap;
 
@@ -113,6 +115,264 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         InferOk {
             value: (value, instantiator.anon_types),
             obligations: instantiator.obligations,
+        }
+    }
+
+    /// Given the map `anon_types` containing the existential `impl
+    /// Trait` types whose underlying, hidden types are being
+    /// inferred, this method adds constraints to the regions
+    /// appearing in those underlying hidden types to ensure that they
+    /// at least do not refer to random scopes within the current
+    /// function. These constraints are not (quite) sufficient to
+    /// guarantee that the regions are actually legal values; that
+    /// final condition is imposed after region inference is done.
+    ///
+    /// # The Problem
+    ///
+    /// Let's work through an example to explain how it works.  Assume
+    /// the current function is as follows:
+    ///
+    ///     fn foo<'a, 'b>(..) -> (impl Bar<'a>, impl Bar<'b>)
+    ///
+    /// Here, we have two `impl Trait` types whose values are being
+    /// inferred (the `impl Bar<'a>` and the `impl
+    /// Bar<'b>`). Conceptually, this is sugar for a setup where we
+    /// define underlying abstract types (`Foo1`, `Foo2`) and then, in
+    /// the return type of `foo`, we *reference* those definitions:
+    ///
+    ///     abstract type Foo1<'x>: Bar<'x>;
+    ///     abstract type Foo2<'x>: Bar<'x>;
+    ///     fn foo<'a, 'b>(..) -> (Foo1<'a>, Foo2<'b>) { .. }
+    ///                        //  ^^^^ ^^
+    ///                        //  |    |
+    ///                        //  |    substs
+    ///                        //  def_id
+    ///
+    /// As indicating in the comments above, each of those references
+    /// is (in the compiler) basically a substitution (`substs`)
+    /// applied to the type of a suitable `def_id` (which identifies
+    /// `Foo1` or `Foo2`).
+    ///
+    /// Now, at this point in compilation, what we have done is to
+    /// replace each of the references (`Foo1<'a>`, `Foo2<'b>`) with
+    /// fresh inference variables C1 and C2. We wish to use the values
+    /// of these variables to infer the underlying types of `Foo1` and
+    /// `Foo2`.  That is, this gives rise to higher-order (pattern) unification
+    /// constraints like:
+    ///
+    ///     for<'a> (Foo1<'a> = C1)
+    ///     for<'b> (Foo1<'b> = C2)
+    ///
+    /// For these equation to be satisfiable, the types `C1` and `C2`
+    /// can only refer to a limited set of regions. For example, `C1`
+    /// can only refer to `'static` and `'a`, and `C2` can only refer
+    /// to `'static` and `'b`. The job of this function is to impose that
+    /// constraint.
+    ///
+    /// Up to this point, C1 and C2 are basically just random type
+    /// inference variables, and hence they may contain arbitrary
+    /// regions. In fact, it is fairly likely that they do! Consider
+    /// this possible definition of `foo`:
+    ///
+    ///     fn foo<'a, 'b>(x: &'a i32, y: &'b i32) -> (impl Bar<'a>, impl Bar<'b>) {
+    ///         (&*x, &*y)
+    ///     }
+    ///
+    /// Here, the values for the concrete types of the two impl
+    /// traits will include inference variables:
+    ///
+    ///     &'0 i32
+    ///     &'1 i32
+    ///
+    /// Ordinarily, the subtyping rules would ensure that these are
+    /// sufficiently large. But since `impl Bar<'a>` isn't a specific
+    /// type per se, we don't get such constraints by default.  This
+    /// is where this function comes into play. It adds extra
+    /// constraints to ensure that all the regions which appear in the
+    /// inferred type are regions that could validly appear.
+    ///
+    /// This is actually a bit of a tricky constraint in general. We
+    /// want to say that each variable (e.g., `'0``) can only take on
+    /// values that were supplied as arguments to the abstract type
+    /// (e.g., `'a` for `Foo1<'a>`) or `'static`, which is always in
+    /// scope. We don't have a constraint quite of this kind in the current
+    /// region checker.
+    ///
+    /// # The Solution
+    ///
+    /// We make use of the constraint that we *do* have in the `<=`
+    /// relation. To do that, we find the "minimum" of all the
+    /// arguments that appear in the substs: that is, some region
+    /// which is less than all the others. In the case of `Foo1<'a>`,
+    /// that would be `'a` (it's the only choice, after all). Then we
+    /// apply that as a least bound to the variables (e.g., `'a <=
+    /// '0`).
+    ///
+    /// In some cases, there is no minimum. Consider this example:
+    ///
+    ///    fn baz<'a, 'b>() -> impl Trait<'a, 'b> { ... }
+    ///
+    /// Here we would report an error, because `'a` and `'b` have no
+    /// relation to one another.
+    ///
+    /// # The `free_region_relations` parameter
+    ///
+    /// The `free_region_relations` argument is used to find the
+    /// "minimum" of the regions supplied to a given abstract type.
+    /// It must be a relation that can answer whether `'a <= 'b`,
+    /// where `'a` and `'b` are regions that appear in the "substs"
+    /// for the abstract type references (the `<'a>` in `Foo1<'a>`).
+    ///
+    /// Note that we do not impose the constraints based on the
+    /// generic regions from the `Foo1` definition (e.g., `'x`). This
+    /// is because the constraints we are imposing here is basically
+    /// the concern of the one generating the constraining type C1,
+    /// which is the current function. It also means that we can
+    /// take "implied bounds" into account in some cases:
+    ///
+    ///     trait SomeTrait<'a, 'b> { }
+    ///     fn foo<'a, 'b>(_: &'a &'b u32) -> impl SomeTrait<'a, 'b> { .. }
+    ///
+    /// Here, the fact that `'b: 'a` is known only because of the
+    /// implied bounds from the `&'a &'b u32` parameter, and is not
+    /// "inherent" to the abstract type definition.
+    ///
+    /// # Parameters
+    ///
+    /// - `anon_types` -- the map produced by `instantiate_anon_types`
+    /// - `free_region_relations` -- something that can be used to relate
+    ///   the free regions (`'a`) that appear in the impl trait.
+    pub fn constrain_anon_types<FRR: FreeRegionRelations<'tcx>>(
+        &self,
+        anon_types: &AnonTypeMap<'tcx>,
+        free_region_relations: &FRR,
+    ) {
+        debug!("constrain_anon_types()");
+
+        for (&def_id, anon_defn) in anon_types {
+            self.constrain_anon_type(def_id, anon_defn, free_region_relations);
+        }
+    }
+
+    fn constrain_anon_type<FRR: FreeRegionRelations<'tcx>>(
+        &self,
+        def_id: DefId,
+        anon_defn: &AnonTypeDecl<'tcx>,
+        free_region_relations: &FRR,
+    ) {
+        debug!("constrain_anon_type()");
+        debug!("constrain_anon_type: def_id={:?}", def_id);
+        debug!("constrain_anon_type: anon_defn={:#?}", anon_defn);
+
+        let concrete_ty = self.resolve_type_vars_if_possible(&anon_defn.concrete_ty);
+
+        debug!("constrain_anon_type: concrete_ty={:?}", concrete_ty);
+
+        let abstract_type_generics = self.tcx.generics_of(def_id);
+
+        let span = self.tcx.def_span(def_id);
+
+        // If there are required region bounds, we can just skip
+        // ahead.  There will already be a registered region
+        // obligation related `concrete_ty` to those regions.
+        if anon_defn.has_required_region_bounds {
+            return;
+        }
+
+        // There were no `required_region_bounds`,
+        // so we have to search for a `least_region`.
+        // Go through all the regions used as arguments to the
+        // abstract type. These are the parameters to the abstract
+        // type; so in our example above, `substs` would contain
+        // `['a]` for the first impl trait and `'b` for the
+        // second.
+        let mut least_region = None;
+        for region_def in &abstract_type_generics.regions {
+            // Find the index of this region in the list of substitutions.
+            let index = region_def.index as usize;
+
+            // Get the value supplied for this region from the substs.
+            let subst_arg = anon_defn.substs[index].as_region().unwrap();
+
+            // Compute the least upper bound of it with the other regions.
+            debug!("constrain_anon_types: least_region={:?}", least_region);
+            debug!("constrain_anon_types: subst_arg={:?}", subst_arg);
+            match least_region {
+                None => least_region = Some(subst_arg),
+                Some(lr) => {
+                    if free_region_relations.sub_free_regions(lr, subst_arg) {
+                        // keep the current least region
+                    } else if free_region_relations.sub_free_regions(subst_arg, lr) {
+                        // switch to `subst_arg`
+                        least_region = Some(subst_arg);
+                    } else {
+                        // There are two regions (`lr` and
+                        // `subst_arg`) which are not relatable. We can't
+                        // find a best choice.
+                        self.tcx
+                            .sess
+                            .struct_span_err(span, "ambiguous lifetime bound in `impl Trait`")
+                            .span_label(
+                                span,
+                                format!("neither `{}` nor `{}` outlives the other", lr, subst_arg),
+                            )
+                            .emit();
+
+                        least_region = Some(self.tcx.mk_region(ty::ReEmpty));
+                        break;
+                    }
+                }
+            }
+        }
+
+        let least_region = least_region.unwrap_or(self.tcx.types.re_static);
+        debug!("constrain_anon_types: least_region={:?}", least_region);
+
+        // Require that the type `concrete_ty` outlives
+        // `least_region`, modulo any type parameters that appear
+        // in the type, which we ignore. This is because impl
+        // trait values are assumed to capture all the in-scope
+        // type parameters. This little loop here just invokes
+        // `outlives` repeatedly, draining all the nested
+        // obligations that result.
+        let mut types = vec![concrete_ty];
+        let bound_region = |r| self.sub_regions(infer::CallReturn(span), least_region, r);
+        while let Some(ty) = types.pop() {
+            let mut components = self.tcx.outlives_components(ty);
+            while let Some(component) = components.pop() {
+                match component {
+                    Component::Region(r) => {
+                        bound_region(r);
+                    }
+
+                    Component::Param(_) => {
+                        // ignore type parameters like `T`, they are captured
+                        // implicitly by the `impl Trait`
+                    }
+
+                    Component::UnresolvedInferenceVariable(_) => {
+                        // we should get an error that more type
+                        // annotations are needed in this case
+                        self.tcx
+                            .sess
+                            .delay_span_bug(span, "unresolved inf var in anon");
+                    }
+
+                    Component::Projection(ty::ProjectionTy {
+                        substs,
+                        item_def_id: _,
+                    }) => {
+                        for r in substs.regions() {
+                            bound_region(r);
+                        }
+                        types.extend(substs.types());
+                    }
+
+                    Component::EscapingProjection(more_components) => {
+                        components.extend(more_components);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -48,6 +48,7 @@ use self::outlives::env::OutlivesEnvironment;
 use self::type_variable::TypeVariableOrigin;
 use self::unify_key::ToType;
 
+pub mod anon_types;
 pub mod at;
 mod combine;
 mod equate;

--- a/src/librustc/middle/free_region.rs
+++ b/src/librustc/middle/free_region.rs
@@ -15,7 +15,7 @@
 //! `TransitiveRelation` type and use that to decide when one free
 //! region outlives another and so forth.
 
-use infer::outlives::free_region_map::FreeRegionMap;
+use infer::outlives::free_region_map::{FreeRegionMap, FreeRegionRelations};
 use hir::def_id::DefId;
 use middle::region;
 use ty::{self, TyCtxt, Region};

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -865,13 +865,17 @@ impl fmt::Debug for ty::RegionVid {
 define_print! {
     () ty::InferTy, (self, f, cx) {
         display {
-            match *self {
-                ty::TyVar(_) => write!(f, "_"),
-                ty::IntVar(_) => write!(f, "{}", "{integer}"),
-                ty::FloatVar(_) => write!(f, "{}", "{float}"),
-                ty::FreshTy(v) => write!(f, "FreshTy({})", v),
-                ty::FreshIntTy(v) => write!(f, "FreshIntTy({})", v),
-                ty::FreshFloatTy(v) => write!(f, "FreshFloatTy({})", v)
+            if cx.is_verbose {
+                print!(f, cx, print_debug(self))
+            } else {
+                match *self {
+                    ty::TyVar(_) => write!(f, "_"),
+                    ty::IntVar(_) => write!(f, "{}", "{integer}"),
+                    ty::FloatVar(_) => write!(f, "{}", "{float}"),
+                    ty::FreshTy(v) => write!(f, "FreshTy({})", v),
+                    ty::FreshIntTy(v) => write!(f, "FreshIntTy({})", v),
+                    ty::FreshFloatTy(v) => write!(f, "FreshFloatTy({})", v)
+                }
             }
         }
         debug {

--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -79,16 +79,12 @@ pub(in borrow_check) fn compute_regions<'cx, 'gcx, 'tcx>(
     // Run the MIR type-checker.
     let mir_node_id = infcx.tcx.hir.as_local_node_id(def_id).unwrap();
     let liveness = &LivenessResults::compute(mir);
-    let fr_fn_body = infcx.tcx.mk_region(ty::ReVar(universal_regions.fr_fn_body));
     let constraint_sets = &type_check::type_check(
         infcx,
         mir_node_id,
         param_env,
         mir,
-        &universal_regions.region_bound_pairs,
-        fr_fn_body,
-        universal_regions.input_tys,
-        universal_regions.output_ty,
+        &universal_regions,
         &liveness,
         flow_inits,
         move_data,

--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -77,13 +77,12 @@ pub(in borrow_check) fn compute_regions<'cx, 'gcx, 'tcx>(
     Option<ClosureRegionRequirements<'gcx>>,
 ) {
     // Run the MIR type-checker.
-    let mir_node_id = infcx.tcx.hir.as_local_node_id(def_id).unwrap();
     let liveness = &LivenessResults::compute(mir);
     let constraint_sets = &type_check::type_check(
         infcx,
-        mir_node_id,
         param_env,
         mir,
+        def_id,
         &universal_regions,
         &liveness,
         flow_inits,

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -244,13 +244,15 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             .map(|origin| RegionDefinition::new(origin))
             .collect();
 
+        let nll_dump_cause = ty::tls::with(|tcx| tcx.sess.opts.debugging_opts.nll_dump_cause);
+
         let mut result = Self {
             definitions,
             elements: elements.clone(),
             liveness_constraints: RegionValues::new(
                 elements,
                 num_region_variables,
-                TrackCauses(true),
+                TrackCauses(nll_dump_cause),
             ),
             inferred_values: None,
             constraints: Vec::new(),

--- a/src/librustc_mir/borrow_check/nll/type_check/input_output.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/input_output.rs
@@ -17,9 +17,15 @@
 //! `RETURN_PLACE` the MIR arguments) are always fully normalize (and
 //! contain revealed `impl Trait` values).
 
+use borrow_check::nll::renumber;
 use borrow_check::nll::universal_regions::UniversalRegions;
+use rustc::hir::def_id::DefId;
+use rustc::infer::InferOk;
 use rustc::ty::Ty;
+use rustc::ty::subst::Subst;
 use rustc::mir::*;
+use rustc::mir::visit::TyContext;
+use rustc::traits::PredicateObligations;
 
 use rustc_data_structures::indexed_vec::Idx;
 
@@ -29,13 +35,17 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
     pub(super) fn equate_inputs_and_outputs(
         &mut self,
         mir: &Mir<'tcx>,
+        mir_def_id: DefId,
         universal_regions: &UniversalRegions<'tcx>,
     ) {
+        let tcx = self.infcx.tcx;
+
         let &UniversalRegions {
             unnormalized_output_ty,
             unnormalized_input_tys,
             ..
         } = universal_regions;
+        let infcx = self.infcx;
 
         let start_position = Location {
             block: START_BLOCK,
@@ -52,10 +62,88 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
 
         // Return types are a bit more complex. They may contain existential `impl Trait`
         // types.
-
+        debug!(
+            "equate_inputs_and_outputs: unnormalized_output_ty={:?}",
+            unnormalized_output_ty
+        );
         let output_ty = self.normalize(&unnormalized_output_ty, start_position);
+        debug!(
+            "equate_inputs_and_outputs: normalized output_ty={:?}",
+            output_ty
+        );
         let mir_output_ty = mir.local_decls[RETURN_PLACE].ty;
-        self.equate_normalized_input_or_output(start_position, output_ty, mir_output_ty);
+        let anon_type_map = self.fully_perform_op(start_position.at_self(), |cx| {
+            let mut obligations = ObligationAccumulator::default();
+
+            let (output_ty, anon_type_map) = obligations.add(infcx.instantiate_anon_types(
+                mir_def_id,
+                cx.body_id,
+                cx.param_env,
+                &output_ty,
+            ));
+            debug!(
+                "equate_inputs_and_outputs: instantiated output_ty={:?}",
+                output_ty
+            );
+            debug!(
+                "equate_inputs_and_outputs: anon_type_map={:#?}",
+                anon_type_map
+            );
+
+            debug!(
+                "equate_inputs_and_outputs: mir_output_ty={:?}",
+                mir_output_ty
+            );
+            obligations.add(infcx
+                .at(&cx.misc(cx.last_span), cx.param_env)
+                .eq(output_ty, mir_output_ty)?);
+
+            for (&anon_def_id, anon_decl) in &anon_type_map {
+                let anon_defn_ty = tcx.type_of(anon_def_id);
+                let anon_defn_ty = anon_defn_ty.subst(tcx, anon_decl.substs);
+                let anon_defn_ty = renumber::renumber_regions(
+                    cx.infcx,
+                    TyContext::Location(start_position),
+                    &anon_defn_ty,
+                );
+                debug!(
+                    "equate_inputs_and_outputs: concrete_ty={:?}",
+                    anon_decl.concrete_ty
+                );
+                debug!("equate_inputs_and_outputs: anon_defn_ty={:?}", anon_defn_ty);
+                obligations.add(infcx
+                    .at(&cx.misc(cx.last_span), cx.param_env)
+                    .eq(anon_decl.concrete_ty, anon_defn_ty)?);
+            }
+
+            debug!("equate_inputs_and_outputs: equated");
+
+            Ok(InferOk {
+                value: Some(anon_type_map),
+                obligations: obligations.into_vec(),
+            })
+        }).unwrap_or_else(|terr| {
+                span_mirbug!(
+                    self,
+                    start_position,
+                    "equate_inputs_and_outputs: `{:?}=={:?}` failed with `{:?}`",
+                    output_ty,
+                    mir_output_ty,
+                    terr
+                );
+                None
+            });
+
+        // Finally
+        if let Some(anon_type_map) = anon_type_map {
+            self.fully_perform_op(start_position.at_self(), |_cx| {
+                infcx.constrain_anon_types(&anon_type_map, universal_regions);
+                Ok(InferOk {
+                    value: (),
+                    obligations: vec![],
+                })
+            }).unwrap();
+        }
     }
 
     fn equate_normalized_input_or_output(&mut self, location: Location, a: Ty<'tcx>, b: Ty<'tcx>) {
@@ -71,5 +159,22 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
                 terr
             );
         }
+    }
+}
+
+#[derive(Debug, Default)]
+struct ObligationAccumulator<'tcx> {
+    obligations: PredicateObligations<'tcx>,
+}
+
+impl<'tcx> ObligationAccumulator<'tcx> {
+    fn add<T>(&mut self, value: InferOk<'tcx, T>) -> T {
+        let InferOk { value, obligations } = value;
+        self.obligations.extend(obligations);
+        value
+    }
+
+    fn into_vec(self) -> PredicateObligations<'tcx> {
+        self.obligations
     }
 }

--- a/src/librustc_mir/borrow_check/nll/type_check/input_output.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/input_output.rs
@@ -1,0 +1,75 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This module contains code to equate the input/output types appearing
+//! in the MIR with the expected input/output types from the function
+//! signature. This requires a bit of processing, as the expected types
+//! are supplied to us before normalization and may contain existential
+//! `impl Trait` instances. In contrast, the input/output types found in
+//! the MIR (specifically, in the special local variables for the
+//! `RETURN_PLACE` the MIR arguments) are always fully normalize (and
+//! contain revealed `impl Trait` values).
+
+use borrow_check::nll::universal_regions::UniversalRegions;
+use rustc::ty::Ty;
+use rustc::mir::*;
+
+use rustc_data_structures::indexed_vec::Idx;
+
+use super::{AtLocation, TypeChecker};
+
+impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
+    pub(super) fn equate_inputs_and_outputs(
+        &mut self,
+        mir: &Mir<'tcx>,
+        universal_regions: &UniversalRegions<'tcx>,
+    ) {
+        let &UniversalRegions {
+            unnormalized_output_ty,
+            unnormalized_input_tys,
+            ..
+        } = universal_regions;
+
+        let start_position = Location {
+            block: START_BLOCK,
+            statement_index: 0,
+        };
+
+        // Equate expected input tys with those in the MIR.
+        let argument_locals = (1..).map(Local::new);
+        for (&unnormalized_input_ty, local) in unnormalized_input_tys.iter().zip(argument_locals) {
+            let input_ty = self.normalize(&unnormalized_input_ty, start_position);
+            let mir_input_ty = mir.local_decls[local].ty;
+            self.equate_normalized_input_or_output(start_position, input_ty, mir_input_ty);
+        }
+
+        // Return types are a bit more complex. They may contain existential `impl Trait`
+        // types.
+
+        let output_ty = self.normalize(&unnormalized_output_ty, start_position);
+        let mir_output_ty = mir.local_decls[RETURN_PLACE].ty;
+        self.equate_normalized_input_or_output(start_position, output_ty, mir_output_ty);
+    }
+
+    fn equate_normalized_input_or_output(&mut self, location: Location, a: Ty<'tcx>, b: Ty<'tcx>) {
+        debug!("equate_normalized_input_or_output(a={:?}, b={:?})", a, b);
+
+        if let Err(terr) = self.eq_types(a, b, location.at_self()) {
+            span_mirbug!(
+                self,
+                location,
+                "equate_normalized_input_or_output: `{:?}=={:?}` failed with `{:?}`",
+                a,
+                b,
+                terr
+            );
+        }
+    }
+}

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -36,7 +36,32 @@ use util::liveness::LivenessResults;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::indexed_vec::Idx;
 
+macro_rules! span_mirbug {
+    ($context:expr, $elem:expr, $($message:tt)*) => ({
+        $crate::borrow_check::nll::type_check::mirbug(
+            $context.tcx(),
+            $context.last_span,
+            &format!(
+                "broken MIR in {:?} ({:?}): {}",
+                $context.body_id,
+                $elem,
+                format_args!($($message)*),
+            ),
+        )
+    })
+}
+
+macro_rules! span_mirbug_and_err {
+    ($context:expr, $elem:expr, $($message:tt)*) => ({
+        {
+            span_mirbug!($context, $elem, $($message)*);
+            $context.error()
+        }
+    })
+}
+
 mod liveness;
+mod input_output;
 
 /// Type checks the given `mir` in the context of the inference
 /// context `infcx`. Returns any region constraints that have yet to
@@ -88,18 +113,7 @@ pub(crate) fn type_check<'gcx, 'tcx>(
         &mut |cx| {
             liveness::generate(cx, mir, liveness, flow_inits, move_data);
 
-            // Equate the input and output tys given by the user with
-            // the ones found in the MIR.
-            let &UniversalRegions {
-                unnormalized_output_ty,
-                unnormalized_input_tys,
-                ..
-            } = universal_regions;
-            cx.equate_input_or_output(unnormalized_output_ty, mir.local_decls[RETURN_PLACE].ty);
-            let arg_locals = (1..).map(Local::new);
-            for (&input_ty, local) in unnormalized_input_tys.iter().zip(arg_locals) {
-                cx.equate_input_or_output(input_ty, mir.local_decls[local].ty);
-            }
+            cx.equate_inputs_and_outputs(mir, universal_regions);
         },
     )
 }
@@ -136,31 +150,11 @@ fn type_check_internal<'gcx, 'tcx>(
     checker.constraints
 }
 
-
 fn mirbug(tcx: TyCtxt, span: Span, msg: &str) {
     // We sometimes see MIR failures (notably predicate failures) due to
     // the fact that we check rvalue sized predicates here. So use `delay_span_bug`
     // to avoid reporting bugs in those cases.
     tcx.sess.diagnostic().delay_span_bug(span, msg);
-}
-
-macro_rules! span_mirbug {
-    ($context:expr, $elem:expr, $($message:tt)*) => ({
-        mirbug($context.tcx(), $context.last_span,
-               &format!("broken MIR in {:?} ({:?}): {}",
-                        $context.body_id,
-                        $elem,
-                        format_args!($($message)*)))
-    })
-}
-
-macro_rules! span_mirbug_and_err {
-    ($context:expr, $elem:expr, $($message:tt)*) => ({
-        {
-            span_mirbug!($context, $elem, $($message)*);
-            $context.error()
-        }
-    })
 }
 
 enum FieldAccessError {
@@ -704,25 +698,6 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
                 .at(&this.misc(this.last_span), this.param_env)
                 .eq(b, a)
         })
-    }
-
-    fn equate_input_or_output(&mut self, unnormalized_a: Ty<'tcx>, b: Ty<'tcx>) {
-        let start_position = Location {
-            block: START_BLOCK,
-            statement_index: 0,
-        };
-        let a = self.normalize(&unnormalized_a, start_position);
-        if let Err(terr) = self.eq_types(a, b, start_position.at_self()) {
-            span_mirbug!(
-                self,
-                start_position,
-                "bad input or output {:?} normalized to {:?} should equal {:?} but got error {:?}",
-                unnormalized_a,
-                a,
-                b,
-                terr
-            );
-        }
     }
 
     fn tcx(&self) -> TyCtxt<'a, 'gcx, 'tcx> {

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -13,6 +13,7 @@
 
 use borrow_check::nll::region_infer::Cause;
 use borrow_check::nll::region_infer::ClosureRegionRequirementsExt;
+use borrow_check::nll::universal_regions::UniversalRegions;
 use dataflow::MaybeInitializedLvals;
 use dataflow::flow_in_progress::FlowInProgress;
 use dataflow::move_paths::MoveData;
@@ -71,28 +72,32 @@ pub(crate) fn type_check<'gcx, 'tcx>(
     body_id: ast::NodeId,
     param_env: ty::ParamEnv<'gcx>,
     mir: &Mir<'tcx>,
-    region_bound_pairs: &[(ty::Region<'tcx>, GenericKind<'tcx>)],
-    implicit_region_bound: ty::Region<'tcx>,
-    input_tys: &[Ty<'tcx>],
-    output_ty: Ty<'tcx>,
+    universal_regions: &UniversalRegions<'tcx>,
     liveness: &LivenessResults,
     flow_inits: &mut FlowInProgress<MaybeInitializedLvals<'_, 'gcx, 'tcx>>,
     move_data: &MoveData<'tcx>,
 ) -> MirTypeckRegionConstraints<'tcx> {
+    let implicit_region_bound = infcx.tcx.mk_region(ty::ReVar(universal_regions.fr_fn_body));
     type_check_internal(
         infcx,
         body_id,
         param_env,
         mir,
-        region_bound_pairs,
+        &universal_regions.region_bound_pairs,
         Some(implicit_region_bound),
         &mut |cx| {
             liveness::generate(cx, mir, liveness, flow_inits, move_data);
 
             // Equate the input and output tys given by the user with
             // the ones found in the MIR.
-            cx.equate_input_or_output(output_ty, mir.local_decls[RETURN_PLACE].ty);
-            for (&input_ty, local) in input_tys.iter().zip((1..).map(Local::new)) {
+            let &UniversalRegions {
+                unnormalized_output_ty,
+                unnormalized_input_tys,
+                ..
+            } = universal_regions;
+            cx.equate_input_or_output(unnormalized_output_ty, mir.local_decls[RETURN_PLACE].ty);
+            let arg_locals = (1..).map(Local::new);
+            for (&input_ty, local) in unnormalized_input_tys.iter().zip(arg_locals) {
                 cx.equate_input_or_output(input_ty, mir.local_decls[local].ty);
             }
         },

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -17,6 +17,7 @@ use borrow_check::nll::universal_regions::UniversalRegions;
 use dataflow::MaybeInitializedLvals;
 use dataflow::flow_in_progress::FlowInProgress;
 use dataflow::move_paths::MoveData;
+use rustc::hir::def_id::DefId;
 use rustc::infer::{InferCtxt, InferOk, InferResult, LateBoundRegionConversionTime, UnitResult};
 use rustc::infer::region_constraints::{GenericKind, RegionConstraintData};
 use rustc::traits::{self, FulfillmentContext};
@@ -77,9 +78,9 @@ mod input_output;
 /// # Parameters
 ///
 /// - `infcx` -- inference context to use
-/// - `body_id` -- body-id of the MIR being checked
 /// - `param_env` -- parameter environment to use for trait solving
 /// - `mir` -- MIR to type-check
+/// - `mir_def_id` -- DefId from which the MIR is derived (must be local)
 /// - `region_bound_pairs` -- the implied outlives obligations between type parameters
 ///   and lifetimes (e.g., `&'a T` implies `T: 'a`)
 /// - `implicit_region_bound` -- a region which all generic parameters are assumed
@@ -94,14 +95,15 @@ mod input_output;
 /// - `move_data` -- move-data constructed when performing the maybe-init dataflow analysis
 pub(crate) fn type_check<'gcx, 'tcx>(
     infcx: &InferCtxt<'_, 'gcx, 'tcx>,
-    body_id: ast::NodeId,
     param_env: ty::ParamEnv<'gcx>,
     mir: &Mir<'tcx>,
+    mir_def_id: DefId,
     universal_regions: &UniversalRegions<'tcx>,
     liveness: &LivenessResults,
     flow_inits: &mut FlowInProgress<MaybeInitializedLvals<'_, 'gcx, 'tcx>>,
     move_data: &MoveData<'tcx>,
 ) -> MirTypeckRegionConstraints<'tcx> {
+    let body_id = infcx.tcx.hir.as_local_node_id(mir_def_id).unwrap();
     let implicit_region_bound = infcx.tcx.mk_region(ty::ReVar(universal_regions.fr_fn_body));
     type_check_internal(
         infcx,
@@ -113,7 +115,7 @@ pub(crate) fn type_check<'gcx, 'tcx>(
         &mut |cx| {
             liveness::generate(cx, mir, liveness, flow_inits, move_data);
 
-            cx.equate_inputs_and_outputs(mir, universal_regions);
+            cx.equate_inputs_and_outputs(mir, mir_def_id, universal_regions);
         },
     )
 }

--- a/src/librustc_mir/borrow_check/nll/universal_regions.rs
+++ b/src/librustc_mir/borrow_check/nll/universal_regions.rs
@@ -70,14 +70,16 @@ pub struct UniversalRegions<'tcx> {
     pub defining_ty: DefiningTy<'tcx>,
 
     /// The return type of this function, with all regions replaced by
-    /// their universal `RegionVid` equivalents. This type is **NOT
-    /// NORMALIZED**.
-    pub output_ty: Ty<'tcx>,
+    /// their universal `RegionVid` equivalents.
+    ///
+    /// NB. This type is not normalized, as the name suggests. =)
+    pub unnormalized_output_ty: Ty<'tcx>,
 
     /// The fully liberated input types of this function, with all
     /// regions replaced by their universal `RegionVid` equivalents.
-    /// This type is **NOT NORMALIZED**.
-    pub input_tys: &'tcx [Ty<'tcx>],
+    ///
+    /// NB. These types are not normalized, as the name suggests. =)
+    pub unnormalized_input_tys: &'tcx [Ty<'tcx>],
 
     /// Each RBP `('a, GK)` indicates that `GK: 'a` can be assumed to
     /// be true. These encode relationships like `T: 'a` that are
@@ -475,7 +477,8 @@ impl<'cx, 'gcx, 'tcx> UniversalRegionsBuilder<'cx, 'gcx, 'tcx> {
             self.relations.relate_universal_regions(fr, fr_fn_body);
         }
 
-        let (output_ty, input_tys) = inputs_and_output.split_last().unwrap();
+        let (unnormalized_output_ty, unnormalized_input_tys) =
+            inputs_and_output.split_last().unwrap();
 
         // we should not have created any more variables
         assert_eq!(self.infcx.num_region_vars(), num_universals);
@@ -504,8 +507,8 @@ impl<'cx, 'gcx, 'tcx> UniversalRegionsBuilder<'cx, 'gcx, 'tcx> {
             first_local_index,
             num_universals,
             defining_ty,
-            output_ty,
-            input_tys,
+            unnormalized_output_ty,
+            unnormalized_input_tys,
             region_bound_pairs: self.region_bound_pairs,
             relations: self.relations,
         }

--- a/src/librustc_mir/borrow_check/nll/universal_regions.rs
+++ b/src/librustc_mir/borrow_check/nll/universal_regions.rs
@@ -27,6 +27,7 @@ use rustc::hir::def_id::DefId;
 use rustc::infer::{InferCtxt, NLLRegionVariableOrigin};
 use rustc::infer::region_constraints::GenericKind;
 use rustc::infer::outlives::bounds::{self, OutlivesBound};
+use rustc::infer::outlives::free_region_map::FreeRegionRelations;
 use rustc::ty::{self, RegionVid, Ty, TyCtxt};
 use rustc::ty::fold::TypeFoldable;
 use rustc::ty::subst::Substs;
@@ -480,9 +481,6 @@ impl<'cx, 'gcx, 'tcx> UniversalRegionsBuilder<'cx, 'gcx, 'tcx> {
         let (unnormalized_output_ty, unnormalized_input_tys) =
             inputs_and_output.split_last().unwrap();
 
-        // we should not have created any more variables
-        assert_eq!(self.infcx.num_region_vars(), num_universals);
-
         debug!(
             "build: global regions = {}..{}",
             FIRST_GLOBAL_INDEX,
@@ -780,5 +778,18 @@ impl<'tcx> UniversalRegionIndices<'tcx> {
         tcx.fold_regions(value, &mut false, |region, _| {
             tcx.mk_region(ty::ReVar(self.to_region_vid(region)))
         })
+    }
+}
+
+/// This trait is used by the `impl-trait` constraint code to abstract
+/// over the `FreeRegionMap` from lexical regions and
+/// `UniversalRegions` (from NLL)`.
+impl<'tcx> FreeRegionRelations<'tcx> for UniversalRegions<'tcx> {
+    fn sub_free_regions(&self, shorter: ty::Region<'tcx>, longer: ty::Region<'tcx>) -> bool {
+        let shorter = shorter.to_region_vid();
+        assert!(self.is_universal_region(shorter));
+        let longer = longer.to_region_vid();
+        assert!(self.is_universal_region(longer));
+        self.outlives(longer, shorter)
     }
 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -985,7 +985,7 @@ fn check_fn<'a, 'gcx, 'tcx>(inherited: &'a Inherited<'a, 'gcx, 'tcx>,
 
     let ret_ty = fn_sig.output();
     fcx.require_type_is_sized(ret_ty, decl.output.span(), traits::SizedReturnType);
-    let ret_ty = fcx.instantiate_anon_types_from_return_value(&ret_ty);
+    let ret_ty = fcx.instantiate_anon_types_from_return_value(fn_id, &ret_ty);
     fcx.ret_coercion = Some(RefCell::new(CoerceMany::new(ret_ty)));
     fn_sig = fcx.tcx.mk_fn_sig(
         fn_sig.inputs().iter().cloned(),
@@ -1878,11 +1878,21 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
     /// function with type variables and records the `AnonTypeMap` for
     /// later use during writeback. See
     /// `InferCtxt::instantiate_anon_types` for more details.
-    fn instantiate_anon_types_from_return_value<T: TypeFoldable<'tcx>>(&self, value: &T) -> T {
-        debug!("instantiate_anon_types_from_return_value(value={:?})", value);
+    fn instantiate_anon_types_from_return_value<T: TypeFoldable<'tcx>>(
+        &self,
+        fn_id: ast::NodeId,
+        value: &T,
+    ) -> T {
+        let fn_def_id = self.tcx.hir.local_def_id(fn_id);
+        debug!(
+            "instantiate_anon_types_from_return_value(fn_def_id={:?}, value={:?})",
+            fn_def_id,
+            value
+        );
 
         let (value, anon_type_map) = self.register_infer_ok_obligations(
             self.instantiate_anon_types(
+                fn_def_id,
                 self.body_id,
                 self.param_env,
                 value,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -90,6 +90,7 @@ use hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use std::slice;
 use namespace::Namespace;
 use rustc::infer::{self, InferCtxt, InferOk, RegionVariableOrigin};
+use rustc::infer::anon_types::AnonTypeDecl;
 use rustc::infer::type_variable::{TypeVariableOrigin};
 use rustc::middle::region;
 use rustc::ty::subst::{Kind, Subst, Substs};
@@ -97,7 +98,7 @@ use rustc::traits::{self, FulfillmentContext, ObligationCause, ObligationCauseCo
 use rustc::ty::{ParamTy, LvaluePreference, NoPreference, PreferMutLvalue};
 use rustc::ty::{self, Ty, TyCtxt, Visibility};
 use rustc::ty::adjustment::{Adjust, Adjustment, AutoBorrow};
-use rustc::ty::fold::{BottomUpFolder, TypeFoldable};
+use rustc::ty::fold::TypeFoldable;
 use rustc::ty::maps::Providers;
 use rustc::ty::util::{Representability, IntTypeExt};
 use errors::{DiagnosticBuilder, DiagnosticId};
@@ -223,62 +224,6 @@ pub struct Inherited<'a, 'gcx: 'a+'tcx, 'tcx: 'a> {
     implicit_region_bound: Option<ty::Region<'tcx>>,
 
     body_id: Option<hir::BodyId>,
-}
-
-/// Information about the anonymous, abstract types whose values we
-/// are inferring in this function (these are the `impl Trait` that
-/// appear in the return type).
-#[derive(Debug)]
-struct AnonTypeDecl<'tcx> {
-    /// The substitutions that we apply to the abstract that that this
-    /// `impl Trait` desugars to. e.g., if:
-    ///
-    ///     fn foo<'a, 'b, T>() -> impl Trait<'a>
-    ///
-    /// winds up desugared to:
-    ///
-    ///     abstract type Foo<'x, T>: Trait<'x>
-    ///     fn foo<'a, 'b, T>() -> Foo<'a, T>
-    ///
-    /// then `substs` would be `['a, T]`.
-    substs: &'tcx Substs<'tcx>,
-
-    /// The type variable that represents the value of the abstract type
-    /// that we require. In other words, after we compile this function,
-    /// we will be created a constraint like:
-    ///
-    ///     Foo<'a, T> = ?C
-    ///
-    /// where `?C` is the value of this type variable. =) It may
-    /// naturally refer to the type and lifetime parameters in scope
-    /// in this function, though ultimately it should only reference
-    /// those that are arguments to `Foo` in the constraint above. (In
-    /// other words, `?C` should not include `'b`, even though it's a
-    /// lifetime parameter on `foo`.)
-    concrete_ty: Ty<'tcx>,
-
-    /// True if the `impl Trait` bounds include region bounds.
-    /// For example, this would be true for:
-    ///
-    ///     fn foo<'a, 'b, 'c>() -> impl Trait<'c> + 'a + 'b
-    ///
-    /// but false for:
-    ///
-    ///     fn foo<'c>() -> impl Trait<'c>
-    ///
-    /// unless `Trait` was declared like:
-    ///
-    ///     trait Trait<'c>: 'c
-    ///
-    /// in which case it would be true.
-    ///
-    /// This is used during regionck to decide whether we need to
-    /// impose any additional constraints to ensure that region
-    /// variables in `concrete_ty` wind up being constrained to
-    /// something from `substs` (or, at minimum, things that outlive
-    /// the fn body). (Ultimately, writeback is responsible for this
-    /// check.)
-    has_required_region_bounds: bool,
 }
 
 impl<'a, 'gcx, 'tcx> Deref for Inherited<'a, 'gcx, 'tcx> {
@@ -892,8 +837,6 @@ fn typeck_tables_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                                                   &fn_sig);
 
             let fcx = check_fn(&inh, param_env, fn_sig, decl, id, body, false).0;
-            // Ensure anon_types have been instantiated prior to entering regionck
-            fcx.instantiate_anon_types(&fn_sig.output());
             fcx
         } else {
             let fcx = FnCtxt::new(&inh, param_env, body.value.id);
@@ -1042,7 +985,7 @@ fn check_fn<'a, 'gcx, 'tcx>(inherited: &'a Inherited<'a, 'gcx, 'tcx>,
 
     let ret_ty = fn_sig.output();
     fcx.require_type_is_sized(ret_ty, decl.output.span(), traits::SizedReturnType);
-    let ret_ty = fcx.instantiate_anon_types(&ret_ty);
+    let ret_ty = fcx.instantiate_anon_types_from_return_value(&ret_ty);
     fcx.ret_coercion = Some(RefCell::new(CoerceMany::new(ret_ty)));
     fn_sig = fcx.tcx.mk_fn_sig(
         fn_sig.inputs().iter().cloned(),
@@ -1931,60 +1874,28 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         result
     }
 
-    /// Replace all anonymized types with fresh inference variables
-    /// and record them for writeback.
-    fn instantiate_anon_types<T: TypeFoldable<'tcx>>(&self, value: &T) -> T {
-        debug!("instantiate_anon_types(value={:?})", value);
-        value.fold_with(&mut BottomUpFolder { tcx: self.tcx, fldop: |ty| {
-            if let ty::TyAnon(def_id, substs) = ty.sty {
-                debug!("instantiate_anon_types: TyAnon(def_id={:?}, substs={:?})", def_id, substs);
+    /// Replace the anonymized types from the return value of the
+    /// function with type variables and records the `AnonTypeMap` for
+    /// later use during writeback. See
+    /// `InferCtxt::instantiate_anon_types` for more details.
+    fn instantiate_anon_types_from_return_value<T: TypeFoldable<'tcx>>(&self, value: &T) -> T {
+        debug!("instantiate_anon_types_from_return_value(value={:?})", value);
 
-                // Use the same type variable if the exact same TyAnon appears more
-                // than once in the return type (e.g. if it's passed to a type alias).
-                if let Some(anon_defn) = self.anon_types.borrow().get(&def_id) {
-                    return anon_defn.concrete_ty;
-                }
-                let span = self.tcx.def_span(def_id);
-                let ty_var = self.next_ty_var(TypeVariableOrigin::TypeInference(span));
+        let (value, anon_type_map) = self.register_infer_ok_obligations(
+            self.instantiate_anon_types(
+                self.body_id,
+                self.param_env,
+                value,
+            )
+        );
 
-                let predicates_of = self.tcx.predicates_of(def_id);
-                let bounds = predicates_of.instantiate(self.tcx, substs);
-                debug!("instantiate_anon_types: bounds={:?}", bounds);
+        let mut anon_types = self.anon_types.borrow_mut();
+        for (ty, decl) in anon_type_map {
+            let old_value = anon_types.insert(ty, decl);
+            assert!(old_value.is_none(), "instantiated twice: {:?}/{:?}", ty, decl);
+        }
 
-                let required_region_bounds =
-                    self.tcx.required_region_bounds(ty, bounds.predicates.clone());
-                debug!("instantiate_anon_types: required_region_bounds={:?}",
-                       required_region_bounds);
-
-                self.anon_types.borrow_mut().insert(def_id, AnonTypeDecl {
-                    substs,
-                    concrete_ty: ty_var,
-                    has_required_region_bounds: !required_region_bounds.is_empty(),
-                });
-                debug!("instantiate_anon_types: ty_var={:?}", ty_var);
-
-                for predicate in bounds.predicates {
-                    // Change the predicate to refer to the type variable,
-                    // which will be the concrete type, instead of the TyAnon.
-                    // This also instantiates nested `impl Trait`.
-                    let predicate = self.instantiate_anon_types(&predicate);
-
-                    // Require that the predicate holds for the concrete type.
-                    let cause = traits::ObligationCause::new(span,
-                                                             self.body_id,
-                                                             traits::SizedReturnType);
-
-                    debug!("instantiate_anon_types: predicate={:?}", predicate);
-                    self.register_predicate(traits::Obligation::new(cause,
-                                                                    self.param_env,
-                                                                    predicate));
-                }
-
-                ty_var
-            } else {
-                ty
-            }
-        }})
+        value
     }
 
     fn normalize_associated_types_in<T>(&self, span: Span, value: &T) -> T

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -93,7 +93,6 @@ use rustc::ty::{self, Ty};
 use rustc::infer;
 use rustc::infer::outlives::env::OutlivesEnvironment;
 use rustc::ty::adjustment;
-use rustc::ty::outlives::Component;
 
 use std::mem;
 use std::ops::Deref;
@@ -344,7 +343,10 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
                                        body_hir_id,
                                        call_site_region);
 
-        self.constrain_anon_types();
+        self.constrain_anon_types(
+            &self.fcx.anon_types.borrow(),
+            self.outlives_environment.free_region_map(),
+        );
     }
 
     fn visit_region_obligations(&mut self, node_id: ast::NodeId)
@@ -361,194 +363,6 @@ impl<'a, 'gcx, 'tcx> RegionCtxt<'a, 'gcx, 'tcx> {
             self.implicit_region_bound,
             self.param_env,
             self.body_id);
-    }
-
-    /// Go through each of the existential `impl Trait` types that
-    /// appear in the function signature. For example, if the current
-    /// function is as follows:
-    ///
-    ///     fn foo<'a, 'b>(..) -> (impl Bar<'a>, impl Bar<'b>)
-    ///
-    /// we would iterate through the `impl Bar<'a>` and the
-    /// `impl Bar<'b>` here. Remember that each of them has
-    /// their own "abstract type" definition created for them. As
-    /// we iterate, we have a `def_id` that corresponds to this
-    /// definition, and a set of substitutions `substs` that are
-    /// being supplied to this abstract typed definition in the
-    /// signature:
-    ///
-    ///     abstract type Foo1<'x>: Bar<'x>;
-    ///     abstract type Foo2<'x>: Bar<'x>;
-    ///     fn foo<'a, 'b>(..) -> (Foo1<'a>, Foo2<'b>) { .. }
-    ///                            ^^^^ ^^ substs
-    ///                            def_id
-    ///
-    /// In addition, for each of the types we will have a type
-    /// variable `concrete_ty` containing the concrete type that
-    /// this function uses for `Foo1` and `Foo2`. That is,
-    /// conceptually, there is a constraint like:
-    ///
-    ///     for<'a> (Foo1<'a> = C)
-    ///
-    /// where `C` is `concrete_ty`. For this equation to be satisfiable,
-    /// the type `C` can only refer to two regions: `'static` and `'a`.
-    ///
-    /// The problem is that this type `C` may contain arbitrary
-    /// region variables. In fact, it is fairly likely that it
-    /// does!  Consider this possible definition of `foo`:
-    ///
-    ///     fn foo<'a, 'b>(x: &'a i32, y: &'b i32) -> (impl Bar<'a>, impl Bar<'b>) {
-    ///         (&*x, &*y)
-    ///     }
-    ///
-    /// Here, the values for the concrete types of the two impl
-    /// traits will include inference variables:
-    ///
-    ///     &'0 i32
-    ///     &'1 i32
-    ///
-    /// Ordinarily, the subtyping rules would ensure that these are
-    /// sufficiently large.  But since `impl Bar<'a>` isn't a specific
-    /// type per se, we don't get such constraints by default.  This
-    /// is where this function comes into play. It adds extra
-    /// constraints to ensure that all the regions which appear in the
-    /// inferred type are regions that could validly appear.
-    ///
-    /// This is actually a bit of a tricky constraint in general. We
-    /// want to say that each variable (e.g., `'0``) can only take on
-    /// values that were supplied as arguments to the abstract type
-    /// (e.g., `'a` for `Foo1<'a>`) or `'static`, which is always in
-    /// scope. We don't have a constraint quite of this kind in the current
-    /// region checker.
-    ///
-    /// What we *do* have is the `<=` relation. So what we do is to
-    /// find the LUB of all the arguments that appear in the substs:
-    /// in this case, that would be `LUB('a) = 'a`, and then we apply
-    /// that as a least bound to the variables (e.g., `'a <= '0`).
-    ///
-    /// In some cases this is pretty suboptimal. Consider this example:
-    ///
-    ///    fn baz<'a, 'b>() -> impl Trait<'a, 'b> { ... }
-    ///
-    /// Here, the regions `'a` and `'b` appear in the substitutions,
-    /// so we would generate `LUB('a, 'b)` as a kind of "minimal upper
-    /// bound", but that turns out be `'static` -- which is clearly
-    /// too strict!
-    fn constrain_anon_types(&mut self) {
-        debug!("constrain_anon_types()");
-
-        for (&def_id, anon_defn) in self.fcx.anon_types.borrow().iter() {
-            let concrete_ty = self.resolve_type(anon_defn.concrete_ty);
-
-            debug!("constrain_anon_types: def_id={:?}", def_id);
-            debug!("constrain_anon_types: anon_defn={:#?}", anon_defn);
-            debug!("constrain_anon_types: concrete_ty={:?}", concrete_ty);
-
-            let abstract_type_generics = self.tcx.generics_of(def_id);
-
-            let span = self.tcx.def_span(def_id);
-
-            // If there are required region bounds, we can just skip
-            // ahead.  There will already be a registered region
-            // obligation related `concrete_ty` to those regions.
-            if anon_defn.has_required_region_bounds {
-                continue;
-            }
-
-            // There were no `required_region_bounds`,
-            // so we have to search for a `least_region`.
-            // Go through all the regions used as arguments to the
-            // abstract type. These are the parameters to the abstract
-            // type; so in our example above, `substs` would contain
-            // `['a]` for the first impl trait and `'b` for the
-            // second.
-            let mut least_region = None;
-            for region_def in &abstract_type_generics.regions {
-                // Find the index of this region in the list of substitutions.
-                let index = region_def.index as usize;
-
-                // Get the value supplied for this region from the substs.
-                let subst_arg = anon_defn.substs[index].as_region().unwrap();
-
-                // Compute the least upper bound of it with the other regions.
-                debug!("constrain_anon_types: least_region={:?}", least_region);
-                debug!("constrain_anon_types: subst_arg={:?}", subst_arg);
-                match least_region {
-                    None => least_region = Some(subst_arg),
-                    Some(lr) => {
-                        if self.outlives_environment
-                               .free_region_map()
-                               .sub_free_regions(lr, subst_arg) {
-                            // keep the current least region
-                        } else if self.outlives_environment
-                                      .free_region_map()
-                                      .sub_free_regions(subst_arg, lr) {
-                            // switch to `subst_arg`
-                            least_region = Some(subst_arg);
-                        } else {
-                            // There are two regions (`lr` and
-                            // `subst_arg`) which are not relatable. We can't
-                            // find a best choice.
-                            self.tcx
-                                .sess
-                                .struct_span_err(span, "ambiguous lifetime bound in `impl Trait`")
-                                .span_label(span,
-                                            format!("neither `{}` nor `{}` outlives the other",
-                                                    lr, subst_arg))
-                                .emit();
-
-                            least_region = Some(self.tcx.mk_region(ty::ReEmpty));
-                            break;
-                        }
-                    }
-                }
-            }
-
-            let least_region = least_region.unwrap_or(self.tcx.types.re_static);
-            debug!("constrain_anon_types: least_region={:?}", least_region);
-
-            // Require that the type `concrete_ty` outlives
-            // `least_region`, modulo any type parameters that appear
-            // in the type, which we ignore. This is because impl
-            // trait values are assumed to capture all the in-scope
-            // type parameters. This little loop here just invokes
-            // `outlives` repeatedly, draining all the nested
-            // obligations that result.
-            let mut types = vec![concrete_ty];
-            let bound_region = |r| self.sub_regions(infer::CallReturn(span), least_region, r);
-            while let Some(ty) = types.pop() {
-                let mut components = self.tcx.outlives_components(ty);
-                while let Some(component) = components.pop() {
-                    match component {
-                        Component::Region(r) => {
-                            bound_region(r);
-                        }
-
-                        Component::Param(_) => {
-                            // ignore type parameters like `T`, they are captured
-                            // implicitly by the `impl Trait`
-                        }
-
-                        Component::UnresolvedInferenceVariable(_) => {
-                            // we should get an error that more type
-                            // annotations are needed in this case
-                            self.tcx.sess.delay_span_bug(span, "unresolved inf var in anon");
-                        }
-
-                        Component::Projection(ty::ProjectionTy { substs, item_def_id: _ }) => {
-                            for r in substs.regions() {
-                                bound_region(r);
-                            }
-                            types.extend(substs.types());
-                        }
-
-                        Component::EscapingProjection(more_components) => {
-                            components.extend(more_components);
-                        }
-                    }
-                }
-            }
-        }
     }
 
     fn resolve_regions_and_report_errors(&self) {

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -81,6 +81,7 @@ This API is completely unstable and subject to change.
 #![feature(match_default_bindings)]
 #![feature(never_type)]
 #![feature(quote)]
+#![feature(refcell_replace_swap)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(slice_patterns)]
 

--- a/src/test/run-pass/impl-trait/example-calendar.rs
+++ b/src/test/run-pass/impl-trait/example-calendar.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// revisions: normal nll
+//[nll] compile-flags: -Znll -Zborrowck=mir
+
 #![feature(conservative_impl_trait,
            universal_impl_trait,
            fn_traits,

--- a/src/test/ui/nll/ty-outlives/impl-trait-captures.rs
+++ b/src/test/ui/nll/ty-outlives/impl-trait-captures.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:-Znll -Zborrowck=mir -Zverbose
+// ignore-test
+
+#![allow(warnings)]
+#![feature(conservative_impl_trait)]
+
+trait Foo<'a> {
+}
+
+impl<'a, T> Foo<'a> for T { }
+
+fn foo<'a, T>(x: &T) -> impl Foo<'a>
+where
+    T: Debug,
+{
+    x
+        //~^ WARNING not reporting region error due to -Znll
+        //~| ERROR free region `'_#2r` does not outlive free region `'a`
+}
+
+fn main() {}

--- a/src/test/ui/nll/ty-outlives/impl-trait-outlives.rs
+++ b/src/test/ui/nll/ty-outlives/impl-trait-outlives.rs
@@ -1,0 +1,51 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:-Znll -Zborrowck=mir -Zverbose
+
+#![allow(warnings)]
+#![feature(conservative_impl_trait)]
+
+use std::fmt::Debug;
+
+fn no_region<'a, T>(x: Box<T>) -> impl Debug + 'a
+    //~^ WARNING not reporting region error due to -Znll
+where
+    T: Debug,
+{
+    x
+    //~^ ERROR failed type test
+}
+
+fn correct_region<'a, T>(x: Box<T>) -> impl Debug + 'a
+where
+    T: 'a + Debug,
+{
+    x
+}
+
+fn wrong_region<'a, 'b, T>(x: Box<T>) -> impl Debug + 'a
+    //~^ WARNING not reporting region error due to -Znll
+where
+    T: 'b + Debug,
+{
+    x
+    //~^ ERROR failed type test
+}
+
+fn outlives_region<'a, 'b, T>(x: Box<T>) -> impl Debug + 'a
+where
+    T: 'b + Debug,
+    'b: 'a,
+{
+    x
+}
+
+fn main() {}

--- a/src/test/ui/nll/ty-outlives/impl-trait-outlives.stderr
+++ b/src/test/ui/nll/ty-outlives/impl-trait-outlives.stderr
@@ -1,0 +1,26 @@
+warning: not reporting region error due to -Znll
+  --> $DIR/impl-trait-outlives.rs:18:35
+   |
+18 | fn no_region<'a, T>(x: Box<T>) -> impl Debug + 'a
+   |                                   ^^^^^^^^^^^^^^^
+
+warning: not reporting region error due to -Znll
+  --> $DIR/impl-trait-outlives.rs:34:42
+   |
+34 | fn wrong_region<'a, 'b, T>(x: Box<T>) -> impl Debug + 'a
+   |                                          ^^^^^^^^^^^^^^^
+
+error: failed type test: TypeTest { generic_kind: T/#1, lower_bound: '_#1r, point: bb0[0], span: $DIR/impl-trait-outlives.rs:23:5: 23:6, test: IsOutlivedByAnyRegionIn(['_#2r]) }
+  --> $DIR/impl-trait-outlives.rs:23:5
+   |
+23 |     x
+   |     ^
+
+error: failed type test: TypeTest { generic_kind: T/#2, lower_bound: '_#1r, point: bb0[0], span: $DIR/impl-trait-outlives.rs:39:5: 39:6, test: IsOutlivedByAnyRegionIn(['_#2r, '_#3r]) }
+  --> $DIR/impl-trait-outlives.rs:39:5
+   |
+39 |     x
+   |     ^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Previously, use of impl Trait with NLL would cause an ICE.